### PR TITLE
Add TAC reference in the charter

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -42,18 +42,22 @@ Effective July 11, 2019
   - viii) approve procedures for the nomination and election of any Officer or other positions created by the Governing Board; and
   - ix) vote on all decisions or matters coming before the Governing Board.
 
-### 4) Outreach Committee
+### 4) Technical Advisory Council (TAC)
+ - a) Technical matters relating to the Urban Computing Foundation Fund will be managed by the the Technical Advisory Council (TAC) 
+ - b) The TAC is defined by the TAC Charter available at https://github.com/ucfoundation/tac/blob/master/TAC_CHARTER.md .
+
+### 5) Outreach Committee
  - a) The Outreach Committee will include one appointed voting representative from each Premier Member.
  - b) The Outreach Committee will be responsible for the design, development and execution of community outreach efforts on behalf of the Governing Board. The Outreach Committee is expected to coordinate closely with the Governing Board and technical communities to maximize the outreach and visibility of the Technical Project throughout the industry.
  - c) The Governing Board may appoint a chairperson of the Outreach Committee or delegate responsibility for selecting a chairperson to the Outreach Committee. The Outreach Committee chairperson will be responsible for reporting progress back to the Governing Board. The Outreach Committee chairperson may attend meetings of the Governing Board, but, unless the Outreach Committee chairperson is a member of the Governing Board, the Outreach Committee chairperson will not attend as a voting member of the Governing Board.
 
-### 5) Voting
+### 6) Voting
  - a) Quorum for Governing Board and Committee meetings will require at least fifty percent of the voting representatives. If advance notice of the meeting has been given per normal means and timing, the Governing Board may continue to meet even if quorum is not met, but will be prevented from making any decisions at the meeting.
  - b) Ideally decisions will be made based on consensus. If, however, any decision requires a vote to move forward, the representatives of the Governing Board or Committee, as applicable, will vote on a one vote per voting representative basis.
  - c) Except as provided in Section 13.a. or elsewhere in this Charter, decisions by vote at a meeting will require a simple majority vote, provided quorum is met. Except as provided in Section 13.a. or elsewhere in this Charter, decisions by electronic vote without a meeting will require a majority of all voting representatives.
  - d) In the event of a tied vote with respect to an action that cannot be resolved by the Governing Board, the Chair may refer the matter to the LF for assistance in reaching a decision. If there is a tied vote in any Committee that cannot be resolved, the matter may be referred to the Governing Board.
 
-### 6) Subsidiaries and Related Companies
+### 7) Subsidiaries and Related Companies
  - a) Definitions:
   - i) “Subsidiaries” means any entity in which a Member owns, directly or indirectly, more than fifty percent of the voting securities or membership interests of the entity in question;
   - ii) “Related Company” means any entity which controls or is controlled by a Member or which, together with a Member, is under the common control of a third party, in each case where such control results from ownership, either directly or indirectly, of more than fifty percent of the voting securities or membership interests of the entity in question; and
@@ -62,30 +66,30 @@ Effective July 11, 2019
  - c) If a Member is itself a foundation, association, consortium, open source project, membership organization, user group or other entity that has members or sponsors, then the rights and privileges granted to such Member will extend only to the employee-representatives of such Member, and not to its members or sponsors, unless otherwise approved by the Governing Board in a specific case.
  - d) Directed Fund Membership is non-transferable, non-salable and non-assignable, except a Member may transfer its current Membership benefits and obligations to a successor of substantially all of its business or assets, whether by merger, sale or otherwise; provided that the transferee agrees to be bound by this Charter and the Bylaws and policies required by LF membership.
 
-### 7) Good Standing
+### 8) Good Standing
  - a) The Linux Foundation’s Good Standing Policy is available at https://www.linuxfoundation.org/good-standing-policy​ and will apply to Members of this Directed Fund.
 
-### 8) Trademarks
+### 9) Trademarks
  - a) Any trademarks relating to the Directed Fund or the Technical Project, including without limitation any mark relating to any Conformance Program, must be transferred to and held by LF Projects, LLC or the Linux Foundation and available for use pursuant to LF Projects, LLC’s trademark usage policy, available at www.lfprojects.org/trademarks/.
 
-### 9) Antitrust Guidelines
+### 10) Antitrust Guidelines
  - a) All Members must abide by The Linux Foundation’s Antitrust Policy available at http://www.linuxfoundation.org/antitrust-policy.
  - b) All Members must encourage open participation from any organization able to meet the membership requirements, regardless of competitive interests. Put another way, the Governing Board will not seek to exclude any member based on any criteria, requirements or reasons other than those that are reasonable and applied on a non-discriminatory basis to all members.
 
-### 10) Budget
+### 11) Budget
  - a) The Governing Board will approve an annual budget and never commit to spend in excess of funds raised. The budget and the purposes to which it is applied must be consistent with both (a) the non-profit and tax-exempt mission of The Linux Foundation and (b) the goals of the Technical Project.
  - b) The Linux Foundation will provide the Governing Board with regular reports of spend levels against the budget. Under no circumstances will The Linux Foundation have any expectation or obligation to undertake an action on behalf of the Directed Fund or otherwise related to the Directed Fund that is not covered in full by funds raised by the Directed Fund.
  - c) In the event an unbudgeted or otherwise unfunded obligation arises related to the Directed Fund, The Linux Foundation will coordinate with the Governing Board to address gap funding requirements.
 
-### 11) General & Administrative Expenses
+### 12) General & Administrative Expenses
  - a) The Linux Foundation will have custody of and final authority over the usage of any fees, funds and other cash receipts.
  - b) A General & Administrative (G&A) fee will be applied by The Linux Foundation to funds raised to cover Finance, Accounting, and operations. The G&A fee will be 9% of the Directed Fund’s first $1,000,000 of gross receipts each year and 6% of the Directed Fund’s gross receipts each year over $1,000,000.
 
-### 12) General Rules and Operations. ​The Directed Fund activities must:
+### 13) General Rules and Operations. ​The Directed Fund activities must:
  - a) engage in the work of the project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of The Linux Foundation in the open source community;
  - b) respect the rights of all trademark owners, including any branding and usage guidelines;
  - c) engage or coordinate with The Linux Foundation on all outreach, website and marketing activities regarding the Directed Fund or on behalf of the Technical Project that invoke or associate the name of the Technical Project or The Linux Foundation; and
  - d) operate under such rules and procedures as may be approved by the Governing Board and confirmed by The Linux Foundation.
 
-### 13) Amendments
+### 14) Amendments
  - a) This Charter may be amended by a two-thirds vote of the entire Governing Board, subject to approval by The Linux Foundation.


### PR DESCRIPTION
This details the Technical Advisory Council purpose and as being approved by the foundation board. Including the URL where the TAC charter is located.